### PR TITLE
Add: 06 top responsive#13

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -7,10 +7,22 @@
 }
 
 .jumbotron {
-  padding-top: 150px;
+  padding-top: 120px;
   color: #FFFFFF;
   font-family: serif;
 } .title {
   font-size: 80px;
   font-family: 'YuGothic';
+}
+
+@media screen and (max-width:639px) {
+.jumbotron {
+  padding-top: 100px;
+  .title {
+  font-size: 60px;
+  }
+  h5 {
+  font-size: 17px;
+  }
+}
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <title>SongShuffle</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="text-center text-white mt-suto fixed-bottom" style="background-color: #000000;">
+<footer class="text-center text-white mt-suto" style="background-color: #000000;">
   <div class="container p-4">
     <section class="">
       <div class="row">

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -6,8 +6,9 @@
   <br>
   <br>
   <br>
-  <div class="text-center">
-    <%= link_to '新規登録', '#', class: 'btn btn-success' %>
-    <%= link_to 'ログイン', '#', class: 'btn btn-primary' %>
+  <div class="d-grid gap-2 col-6 mx-auto">
+    <%= link_to '新規登録', '#', class: 'btn btn-success btn-lg' %>
+    <br>
+    <%= link_to 'ログイン', '#', class: 'btn btn-primary btn-lg' %>
   </div>
 </div>


### PR DESCRIPTION
## 概要

Top画面のスマートフォンへのレスポンシブ対応

## 詳細

- c28ef47 でレスポンシブ対応のmetaタグ追加
- 3bb83c0 でサイズやバランスの調整
- ff94e11 footerの固定化がどうなるか勘違いしていたので解除
- 1be68c6 ボタンを大きくし、縦並びに変更

　※参考
　[macのrailsサーバーにスマホ実機でアクセスする](https://qiita.com/takahi5/items/8e03f12bec7def84fc52)

## 確認方法

- `bundle exec rails s`を起動し、コマンドラインツールで確認
もしくは
- スマートフォンでパソコンと同じwifiに接続後、パソコンのIPアドレスを確認し、`bundle exec rails s -b  パソコンのIPアドレス`でサーバーを起動。`http://パソコンのIPアドレス:3000/`にスマートフォンからアクセス

## コメント

ご確認よろしくお願い致します。