### PR TITLE
Fix: defaults.ja.ymlの追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,6 @@ class ApplicationController < ActionController::Base
   private
 
   def not_authenticated
-    redirect_to login_path, alert: 'ログインしてください'
+    redirect_to login_path, warning: (t 'defaults.message.require_login')
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       auto_login(@user)
-      redirect_to root_path, success: '登録が完了しました'
+      redirect_to root_path, success: (t '.success')
     else
       flash.now[:danger] = (t '.fail')
       render :new

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -6,9 +6,9 @@
     </button>
     <div class="collapse navbar-collapse justify-content-end" id="navbarNavAltMarkup">
       <div class="navbar-nav">
-        <%= link_to (t 'static_pages.top.sign_up'), new_user_path, class: 'nav-link' %>
+        <%= link_to (t 'defaults.sign_up'), new_user_path, class: 'nav-link' %>
         <%= link_to (t 'user_sessions.new.title'), login_path, class: 'nav-link' %>
-        <%= link_to '使い方', '#', class: 'nav-link' %>
+        <%= link_to '', '#', class: 'nav-link' %>
         <%= link_to '', '#', class: 'nav-link' %>
       </div>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,7 +9,7 @@
         <%= link_to (t 'tracks.index.title'), tracks_search_path, class: 'nav-link' %>
       </div>
       <div class="navbar-nav">
-        <%= link_to (t 'user_sessions.destroy.title'), logout_path, method: :delete, class: 'nav-link' %>
+        <%= link_to (t 'defaults.logout'), logout_path, method: :delete, class: 'nav-link' %>
       </div>
     </div>
   </nav>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -7,8 +7,8 @@
   <br>
   <br>
   <div class="d-grid gap-2 col-6 mx-auto">
-    <%= link_to (t '.sign_up'), new_user_path, class: 'btn btn-success btn-lg' %>
+    <%= link_to (t 'defaults.sign_up'), new_user_path, class: 'btn btn-success btn-lg' %>
     <br>
-    <%= link_to (t 'user_sessions.new.login'), login_path, class: 'btn btn-primary btn-lg' %>
+    <%= link_to (t 'defaults.login'), login_path, class: 'btn btn-primary btn-lg' %>
   </div>
 </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -14,7 +14,7 @@
 					<%= f.password_field :password, class: 'form-control' %>
 				</div>
 				<div class="text-center  button">
-					<%= f.submit (t '.login'), class: 'btn btn-success btn-lg' %>
+					<%= f.submit (t 'defaults.login'), class: 'btn btn-success btn-lg' %>
 				</div>
       <% end %>
 			<div class="text-center">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -23,7 +23,7 @@
 					<%= f.password_field :password_confirmation, class: 'form-control' %>
 				</div>
 				<div class="text-center button">
-					<%= f.submit (t '.register'), class: 'btn btn-success btn-lg' %>
+					<%= f.submit (t 'defaults.register'), class: 'btn btn-success btn-lg' %>
 				</div>
       <% end %>
 			<div class="text-center">

--- a/config/locales/views/defaults.ja.yml
+++ b/config/locales/views/defaults.ja.yml
@@ -1,5 +1,6 @@
 ja:
   defaults:
+    register: '登録'
     sign_up: '新規登録'
     login: 'ログイン'
     logout: 'ログアウト'

--- a/config/locales/views/defaults.ja.yml
+++ b/config/locales/views/defaults.ja.yml
@@ -1,0 +1,7 @@
+ja:
+  defaults:
+    sign_up: '新規登録'
+    login: 'ログイン'
+    logout: 'ログアウト'
+    message:
+      require_login: 'ログインしてください'

--- a/config/locales/views/static_pages.ja.yml
+++ b/config/locales/views/static_pages.ja.yml
@@ -1,4 +1,0 @@
-ja:
-  static_pages:
-    top:
-      sign_up: '新規登録'

--- a/config/locales/views/user_sessions.ja.yml
+++ b/config/locales/views/user_sessions.ja.yml
@@ -2,11 +2,9 @@ ja:
   user_sessions:
     new:
       title: 'ログイン'
-      login: 'ログイン'
       to_register_page: '登録ページへ'
     create:
       success: 'ログインしました'
       fail: 'ログインに失敗しました'
     destroy:
-      title: 'ログアウト'
       success: 'ログアウトしました'


### PR DESCRIPTION
## 概要

- defaults.ja.ymlの追加
- defaults.ja.ymlに移動したコード、ファイルの削除
- view側のパス修正

## チェックリスト

- [x] 曲の検索結果以外全てのページに表示されている文字がしっかり日本語教示されていること

## コメント

前回PRに修正がありましたので、行いました。
ご確認よろしくお願い致します。