### PR TITLE
Fix: ログイン中にログイン画面とユーザー登録画面に飛べないようにする

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -2,7 +2,7 @@ class UserSessionsController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
 
   def new
-    redirect_to root_path, info: 'ログインしています' if logged_in?
+    redirect_to root_path, info: (t 'defaults.message.already_logged_in') if logged_in?
   end
 
   def create

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,7 +1,9 @@
 class UserSessionsController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
 
-  def new; end
+  def new
+    redirect_to root_path, info: 'ログインしています' if logged_in?
+  end
 
   def create
     @user = login(params[:email], params[:password])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
 
   def new
+    return redirect_to root_path, info: 'ログインしています' if logged_in?
     @user = User.new
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
 
   def new
-    return redirect_to root_path, info: 'ログインしています' if logged_in?
+    return redirect_to root_path, info: (t 'defaults.message.already_logged_in') if logged_in?
     @user = User.new
   end
 

--- a/config/locales/views/defaults.ja.yml
+++ b/config/locales/views/defaults.ja.yml
@@ -6,3 +6,4 @@ ja:
     logout: 'ログアウト'
     message:
       require_login: 'ログインしてください'
+      already_logged_in: 'ログインしています'


### PR DESCRIPTION
## 概要

- ログイン中にログイン画面とユーザー登録画面に飛んだ際、別ページにリダイレクトされるようにする

## 確認方法

1. ログインしてください
2. ログイン後にログイン画面に飛ぼうとすると、リダイレクトされ「ログインしています」というフラッシュメッセージが表示されることをご確認ください
3. ログイン後にユーザー登録画面に飛ぼうとすると、リダイレクトされ「ログインしています」というフラッシュメッセージが表示されることをご確認ください

## コメント

ご確認よろしくお願い致します。