### PR TITLE
Fix: ユーザー登録、ログインの処理中に送信ボタンを押せなくする

### DIFF
--- a/app/javascript/pages/users/login.vue
+++ b/app/javascript/pages/users/login.vue
@@ -46,7 +46,7 @@
             @click="login"
             class="mt-10"
             type="submit"
-            :disabled="invalid"
+            :disabled="invalid || loading"
             color="success"
             id="login"
           >
@@ -76,7 +76,8 @@ export default {
         email: '',
         password: ''
       },
-      showPassword: false
+      showPassword: false,
+      loading: false
     }
   },
 
@@ -85,8 +86,10 @@ export default {
       "loginUser"
     ]),
     async login() {
+      this.loading = true
       try {
         await this.loginUser(this.user)
+        this.loading = false
         this.$router.push({ name: 'Top' })
         this.$store.dispatch("flashMessages/showMessage",
           {

--- a/app/javascript/pages/users/register.vue
+++ b/app/javascript/pages/users/register.vue
@@ -86,7 +86,7 @@
           @click="register"
           class="mt-4"
           type="submit"
-          :disabled="invalid"
+          :disabled="invalid || loading"
           color="success"
         >
           登録
@@ -118,6 +118,7 @@ export default {
       // checkbox: null,
       showPassword: false,
       showPasswordConfirmation: false,
+      loading: false
     }
   },
 
@@ -136,8 +137,10 @@ export default {
     },
 
     register() {
+      this.loading = true
       this.$axios.post("users", { user: this.user })
         .then(response => {
+          this.loading = false,
           this.$router.push({ name: 'Login' }),
           this.$store.dispatch("flashMessages/showMessage",
             {


### PR DESCRIPTION
## 概要

- 多重送信を防ぐため、ユーザー登録ページの登録ボタンを送信中ボタンを押せなくする
- 多重送信を防ぐため、ログインページのログインボタンを送信中ボタンを押せなくする

## 確認方法

行った修正をレビュアーが確認するための手順を記載しましょう。例えば以下のように。

1. ユーザー登録ページで情報を入力し、登録を押した瞬間ボタンが暗くなり押せなくなっていること
2. ログインページで情報を入力し、ログインを押した瞬間ボタンが暗くなり押せなくなっていること
---
以上をご確認ください。

## コメント

ご確認よろしくお願い致します。