### PR TITLE
Change: tracksテーブルを変更し、マイライブラリ追加、削除のロジックを合わせて変更 

### DIFF
--- a/app/controllers/api/tracks_controller.rb
+++ b/app/controllers/api/tracks_controller.rb
@@ -22,16 +22,16 @@ class Api::TracksController < ApplicationController
     render json: tracks
   end
 
-  def my_library
-    uri = URI.parse("#{ENV['TRACK_URL']}/#{params[:track_id]}")
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = true
-    header = { 'Authorization' => "Bearer #{@bearer_token}", 'Accept-Language' => 'ja;q=1' }
-    uri.query = URI.encode_www_form({ market: 'JP' })
-    response = http.get(uri.request_uri, header)
-    my_track = JSON.parse(response.body)
-    render json: my_track
-  end
+  # def my_library
+  #   uri = URI.parse("#{ENV['TRACK_URL']}/#{params[:track_id]}")
+  #   http = Net::HTTP.new(uri.host, uri.port)
+  #   http.use_ssl = true
+  #   header = { 'Authorization' => "Bearer #{@bearer_token}", 'Accept-Language' => 'ja;q=1' }
+  #   uri.query = URI.encode_www_form({ market: 'JP' })
+  #   response = http.get(uri.request_uri, header)
+  #   my_track = JSON.parse(response.body)
+  #   render json: my_track
+  # end
 
   def index
     @my_tracks = current_user.tracks.all.order(:id)

--- a/app/controllers/api/tracks_controller.rb
+++ b/app/controllers/api/tracks_controller.rb
@@ -39,7 +39,7 @@ class Api::TracksController < ApplicationController
   end
 
   def create
-    track = current_user.tracks.build(track_id: params[:track_id])
+    track = current_user.tracks.build(track_params)
 
     if track.save
       render json: track
@@ -70,5 +70,9 @@ class Api::TracksController < ApplicationController
 
   def set_track
     @track = current_user.tracks.find(params[:id])
+  end
+
+  def track_params
+    params.require(:track).permit(:track_id, :name, :artist_name, :album_name, :image_url)
   end
 end

--- a/app/javascript/pages/tracks/MyLibrary.vue
+++ b/app/javascript/pages/tracks/MyLibrary.vue
@@ -24,9 +24,17 @@
         :tracks="searchedTracks"
         :library="myLibrary"
         :submitting="submitting"
-        @create-track="handleCreateTrack"
+        @create-track="handleAddTrack"
         @delete-track="handleDeleteTrack"
       >
+        <template
+          v-if="myLibrary.length === 0"
+          v-slot:subheader
+        >
+          <v-subheader>
+            まだ追加された曲はありません
+          </v-subheader>
+        </template>
       </TracksListCard>
     </v-container>
   </div>
@@ -41,7 +49,7 @@ export default {
 
   data() {
     return {
-      myLibraryTracks: [],
+      // myLibraryTracks: [],
       search: '',
       submitting: false
     }
@@ -54,44 +62,44 @@ export default {
   computed: {
     ...mapGetters("myLibrary", ["myLibrary"]),
 
-    sortTracks() {
-      return this.myLibraryTracks.sort((a,b) => a.index - b.index)
-    },
+    // sortTracks() {
+    //   return this.myLibraryTracks.sort((a,b) => a.index - b.index)
+    // },
 
     searchedTracks() {
-      return this.sortTracks.filter(track => {
-        return track.name.toLowerCase().indexOf(this.search.toLowerCase()) != -1 || track.artists[0].name.toLowerCase().indexOf(this.search.toLowerCase()) != -1 || track.album.name.toLowerCase().indexOf(this.search.toLowerCase()) != -1
+      return this.myLibrary.filter(track => {
+        return track.name.toLowerCase().indexOf(this.search.toLowerCase()) != -1 || track.artist_name.toLowerCase().indexOf(this.search.toLowerCase()) != -1 || track.album_name.toLowerCase().indexOf(this.search.toLowerCase()) != -1
       })
     }
   },
 
-  watch: {
-    myLibrary() {
-      const added = this.myLibraryTracks.some(myLibraryTrack => {
-        return this.myLibrary.indexOf(myLibraryTrack.id)
-      })
+  // watch: {
+  //   // myLibrary() {
+  //   //   const added = this.myLibraryTracks.some(myLibraryTrack => {
+  //   //     return this.myLibrary.indexOf(myLibraryTrack.id)
+  //   //   })
 
-      this.myLibrary.forEach((myTrack, index) => {
-        this.$axios.post("tracks/my-library",{ track_id: myTrack.track_id })
-          .then(response => {
-            if (!added) {
-              response.data["index"] = index
-              this.myLibraryTracks.push(response.data)
-            }
-          })
-          .catch(error => {
-            this.$store.dispatch("flashMessages/showMessage",
-              {
-                message: "ライブラリの読み込みに失敗しました",
-                type: "error",
-                status: true
-              }
-            )
-            console.log(error)
-          })
-      })
-    }
-  },
+  //   //   this.myLibrary.forEach((myTrack, index) => {
+  //   //     this.$axios.post("tracks/my-library",{ track_id: myTrack.track_id })
+  //   //       .then(response => {
+  //   //         if (!added) {
+  //   //           response.data["index"] = index
+  //   //           this.myLibraryTracks.push(response.data)
+  //   //         }
+  //   //       })
+  //   //       .catch(error => {
+  //   //         this.$store.dispatch("flashMessages/showMessage",
+  //   //           {
+  //   //             message: "ライブラリの読み込みに失敗しました",
+  //   //             type: "error",
+  //   //             status: true
+  //   //           }
+  //   //         )
+  //   //         console.log(error)
+  //   //       })
+  //   //   })
+  //   // }
+  // },
 
   created() {
     this.fetchTracks()
@@ -100,39 +108,39 @@ export default {
   methods: {
     ...mapActions("myLibrary", [
       "fetchTracks",
-      "createTrack",
+      // "addTrack",
       "deleteTrack",
     ]),
 
-    async handleCreateTrack(trackId) {
-      this.submitting = true
-      try {
-        await this.createTrack(trackId)
-        this.submitting = false
-        this.$store.dispatch("flashMessages/showMessage",
-          {
-            message: "マイライブラリに追加しました",
-            type: "blue lighten-1",
-            status: true
-          }
-        )
-      } catch(error) {
-        this.submitting = false
-        this.$store.dispatch("flashMessages/showMessage",
-          {
-            message: "追加に失敗しました",
-            type: "error",
-            status: true
-          }
-        )
-        console.log(error)
-      }
-    },
+    // async handleAddTrack(addTrack) {
+    //   this.submitting = true
+    //   try {
+    //     await this.addTrack(addTrack)
+    //     this.submitting = false
+    //     this.$store.dispatch("flashMessages/showMessage",
+    //       {
+    //         message: "マイライブラリに追加しました",
+    //         type: "blue lighten-1",
+    //         status: true
+    //       }
+    //     )
+    //   } catch(error) {
+    //     this.submitting = false
+    //     this.$store.dispatch("flashMessages/showMessage",
+    //       {
+    //         message: "追加に失敗しました",
+    //         type: "error",
+    //         status: true
+    //       }
+    //     )
+    //     console.log(error)
+    //   }
+    // },
 
-    async handleDeleteTrack(trackId) {
+    async handleDeleteTrack(deleteTrack) {
       this.submitting = true
       try {
-        await this.deleteTrack(trackId)
+        await this.deleteTrack(deleteTrack)
         this.submitting = false
         this.$store.dispatch("flashMessages/showMessage",
           {

--- a/app/javascript/pages/tracks/MyLibrary.vue
+++ b/app/javascript/pages/tracks/MyLibrary.vue
@@ -34,6 +34,14 @@
             まだ追加された曲はありません
           </v-subheader>
         </template>
+        <template
+          v-else
+          v-slot:subheader
+        >
+          <v-subheader>
+            {{ searchedTracks.length }}曲
+          </v-subheader>
+        </template>
       </TracksListCard>
     </v-container>
   </div>

--- a/app/javascript/pages/tracks/MyLibrary.vue
+++ b/app/javascript/pages/tracks/MyLibrary.vue
@@ -24,7 +24,6 @@
         :tracks="searchedTracks"
         :library="myLibrary"
         :submitting="submitting"
-        @create-track="handleAddTrack"
         @delete-track="handleDeleteTrack"
       >
         <template

--- a/app/javascript/pages/tracks/Search.vue
+++ b/app/javascript/pages/tracks/Search.vue
@@ -42,7 +42,7 @@
         :tracks="displayTracks"
         :library="myLibrary"
         :submitting="submitting"
-        @create-track="handleCreateTrack"
+        @add-track="handleAddTrack"
         @delete-track="handleDeleteTrack"
       >
         <template v-slot:subheader>
@@ -83,7 +83,14 @@ export default {
       lastPage: 1,
       displayTracks: [],
       pageSize: 10,
-      submitting: false
+      submitting: false,
+      track: {
+        track_id: '',
+        name: '',
+        artist_name: '',
+        album_name: '',
+        image_url: ''
+      }
     }
   },
 
@@ -112,7 +119,7 @@ export default {
     ...mapActions("searchTracks", ["searchTracks"]),
     ...mapActions("myLibrary", [
       "fetchTracks",
-      "createTrack",
+      "addTrack",
       "deleteTrack"
     ]),
 
@@ -155,10 +162,15 @@ export default {
       this.displayTracks = this.tracks.slice(this.pageSize*(this.page - 1), this.pageSize*(this.page))
     },
 
-    async handleCreateTrack(trackId) {
+    async handleAddTrack(addTrack) {
+      this.track.track_id = addTrack.id
+      this.track.name = addTrack.name
+      this.track.artist_name = addTrack.artists[0].name
+      this.track.album_name = addTrack.album.name
+      this.track.image_url = addTrack.album.images[0].url
       this.submitting = true
       try {
-        await this.createTrack(trackId)
+        await this.addTrack(this.track)
         this.submitting = false
         this.$store.dispatch("flashMessages/showMessage",
           {
@@ -180,10 +192,15 @@ export default {
       }
     },
 
-    async handleDeleteTrack(trackId) {
+    async handleDeleteTrack(deleteTrack) {
+      this.track.track_id = deleteTrack.id
+      this.track.name = deleteTrack.name
+      this.track.artist_name = deleteTrack.artists[0].name
+      this.track.album_name = deleteTrack.album.name
+      this.track.image_url = deleteTrack.album.images[0].url
       this.submitting = true
       try {
-        await this.deleteTrack(trackId)
+        await this.deleteTrack(this.track)
         this.submitting = false
         this.$store.dispatch("flashMessages/showMessage",
           {

--- a/app/javascript/pages/tracks/components/TracksListCard.vue
+++ b/app/javascript/pages/tracks/components/TracksListCard.vue
@@ -46,6 +46,7 @@
           </v-list-item-icon>
         </v-list-item>
       </div>
+
       <div v-else-if="this.$route.name === 'MyLibrary'">
         <v-list-item
           v-for="(track, index) in this.tracks"
@@ -65,22 +66,12 @@
 
           <v-list-item-icon class="mr-1">
             <v-icon
-              v-if="added(track.track_id)"
               @click="handleDeleteTrack(track)"
               color="white"
               :disabled="submitting"
               id="delete-icon"
             >
               mdi-delete
-            </v-icon>
-            <v-icon
-              v-else
-              @click="handleAddTrack(track)"
-              color="white"
-              :disabled="submitting"
-              id="create-icon"
-            >
-              mdi-plus
             </v-icon>
           </v-list-item-icon>
         </v-list-item>

--- a/app/javascript/pages/tracks/components/TracksListCard.vue
+++ b/app/javascript/pages/tracks/components/TracksListCard.vue
@@ -7,43 +7,84 @@
       <slot
         name="subheader"
       ></slot>
-      <v-list-item
-        v-for="(track, index) in this.tracks"
-        :key="index"
-      >
-        <v-list-item-avatar class="mr-3">
-          <v-img
-            alt="Track image"
-            :src="track.album.images[2].url"
-          ></v-img>
-        </v-list-item-avatar>
+      <div v-if="this.$route.name === 'Search'">
+        <v-list-item
+          v-for="(track, index) in this.tracks"
+          :key="index"
+        >
+          <v-list-item-avatar class="ml-1 mr-3">
+            <v-img
+              alt="Track image"
+              :src="track.album.images[2].url"
+            ></v-img>
+          </v-list-item-avatar>
 
-        <v-list-item-content>
-          <v-list-item-title v-text="track.name"></v-list-item-title>
-          <v-list-item-subtitle v-text="`${track.artists[0].name} - ${track.album.name}`"></v-list-item-subtitle>
-        </v-list-item-content>
+          <v-list-item-content>
+            <v-list-item-title v-text="track.name"></v-list-item-title>
+            <v-list-item-subtitle v-text="`${track.artists[0].name} - ${track.album.name}`"></v-list-item-subtitle>
+          </v-list-item-content>
 
-        <v-list-item-icon class="mr-4">
-          <v-icon
-            v-if="added(track.id)"
-            @click="handleDeleteTrack(track.id)"
-            color="white"
-            :disabled="submitting"
-            id="delete-icon"
-          >
-            mdi-delete
-          </v-icon>
-          <v-icon
-            v-else
-            @click="handleCreateTrack(track.id)"
-            color="white"
-            :disabled="submitting"
-            id="create-icon"
-          >
-            mdi-plus
-          </v-icon>
-        </v-list-item-icon>
-      </v-list-item>
+          <v-list-item-icon class="mr-1">
+            <v-icon
+              v-if="added(track.id)"
+              @click="handleDeleteTrack(track)"
+              color="white"
+              :disabled="submitting"
+              id="delete-icon"
+            >
+              mdi-delete
+            </v-icon>
+            <v-icon
+              v-else
+              @click="handleAddTrack(track)"
+              color="white"
+              :disabled="submitting"
+              id="create-icon"
+            >
+              mdi-plus
+            </v-icon>
+          </v-list-item-icon>
+        </v-list-item>
+      </div>
+      <div v-else-if="this.$route.name === 'MyLibrary'">
+        <v-list-item
+          v-for="(track, index) in this.tracks"
+          :key="index"
+        >
+          <v-list-item-avatar class="ml-1 mr-3">
+            <v-img
+              alt="Track image"
+              :src="track.image_url"
+            ></v-img>
+          </v-list-item-avatar>
+
+          <v-list-item-content>
+            <v-list-item-title v-text="track.name"></v-list-item-title>
+            <v-list-item-subtitle v-text="`${track.artist_name} - ${track.album_name}`"></v-list-item-subtitle>
+          </v-list-item-content>
+
+          <v-list-item-icon class="mr-1">
+            <v-icon
+              v-if="added(track.track_id)"
+              @click="handleDeleteTrack(track)"
+              color="white"
+              :disabled="submitting"
+              id="delete-icon"
+            >
+              mdi-delete
+            </v-icon>
+            <v-icon
+              v-else
+              @click="handleAddTrack(track)"
+              color="white"
+              :disabled="submitting"
+              id="create-icon"
+            >
+              mdi-plus
+            </v-icon>
+          </v-list-item-icon>
+        </v-list-item>
+      </div>
     </v-list>
   </v-card>
 </template>
@@ -80,12 +121,12 @@ export default {
   },
 
   methods: {
-    handleCreateTrack(trackId) {
-      this.$emit('create-track', trackId)
+    handleAddTrack(addTrack) {
+      this.$emit('add-track', addTrack)
     },
 
-    handleDeleteTrack(trackId) {
-      this.$emit('delete-track', trackId)
+    handleDeleteTrack(deleteTrack) {
+      this.$emit('delete-track', deleteTrack)
     }
   }
 }

--- a/app/javascript/store/modules/myLibrary.js
+++ b/app/javascript/store/modules/myLibrary.js
@@ -33,16 +33,16 @@ const actions = {
       .catch(error => console.log(error.status))
   },
 
-  createTrack({ commit }, trackId) {
-    return axios.post('tracks', { track_id: trackId})
+  addTrack({ commit }, addTrack) {
+    return axios.post('tracks', addTrack)
       .then(response => {
         commit('addTrack', response.data)
       })
   },
 
-  deleteTrack({ commit, state }, trackId) {
+  deleteTrack({ commit, state }, track) {
     const deleteTrack = state.myLibrary.filter(myTrack => {
-      return myTrack.track_id.indexOf(trackId) != -1
+      return myTrack.track_id.indexOf(track.track_id) != -1
     })
 
     return axios.delete(`tracks/${deleteTrack[0].id}`, deleteTrack)

--- a/db/migrate/20211212073400_change_tracks_columns.rb
+++ b/db/migrate/20211212073400_change_tracks_columns.rb
@@ -1,0 +1,10 @@
+class ChangeTracksColumns < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tracks, :name, :text
+    add_column :tracks, :artist_name, :text
+    add_column :tracks, :album_name, :text
+    add_column :tracks, :image_url, :text
+    #Ex:- add_column("admin_users", "username", :string, :limit =>25, :after => "email")
+    #Ex:- add_column("admin_users", "username", :string, :limit =>25, :after => "email")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_28_084331) do
+ActiveRecord::Schema.define(version: 2021_12_12_073400) do
 
   create_table "tracks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "track_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "name"
+    t.text "artist_name"
+    t.text "album_name"
+    t.text "image_url"
     t.index ["user_id", "track_id"], name: "index_tracks_on_user_id_and_track_id", unique: true
     t.index ["user_id"], name: "index_tracks_on_user_id"
   end

--- a/spec/system/create_delete_tracks_spec.rb
+++ b/spec/system/create_delete_tracks_spec.rb
@@ -60,32 +60,9 @@ RSpec.describe "CreateDeleteTracks", type: :system do
         find('#delete-icon').click
         sleep 1
         expect(page).to have_content 'マイライブラリから削除しました'
-        expect(find('#tracks-list')).to have_selector '#create-icon'
-        visit current_path
         expect(find('#tracks-list')).not_to have_content ENV['SEARCH_TRACK_NAME']
         expect(find('#tracks-list')).not_to have_content ENV['SEARCH_TRACK_ARTIST_NAME']
         expect(find('#tracks-list')).not_to have_content ENV['SEARCH_TRACK_ALBUM_NAME']
-      end
-    end
-
-    context '表示されている曲を削除し、再度追加する' do
-      it '正常に追加され、ゴミ箱アイコンに戻り、再読み込みをしてもその曲が表示されている' do
-        visit "/mylibrary"
-        expect(find('#tracks-list')).to have_content ENV['SEARCH_TRACK_NAME']
-        expect(find('#tracks-list')).to have_content ENV['SEARCH_TRACK_ARTIST_NAME']
-        expect(find('#tracks-list')).to have_content ENV['SEARCH_TRACK_ALBUM_NAME']
-        expect(find('#tracks-list')).to have_selector '#delete-icon'
-        find('#delete-icon').click
-        expect(page).to have_content 'マイライブラリから削除しました'
-        expect(find('#tracks-list')).to have_selector '#create-icon'
-        find('#create-icon').click
-        sleep 1
-        expect(page).to have_content 'マイライブラリに追加しました'
-        expect(find('#tracks-list')).to have_selector '#delete-icon'
-        visit current_path
-        expect(find('#tracks-list')).to have_content ENV['SEARCH_TRACK_NAME']
-        expect(find('#tracks-list')).to have_content ENV['SEARCH_TRACK_ARTIST_NAME']
-        expect(find('#tracks-list')).to have_content ENV['SEARCH_TRACK_ALBUM_NAME']
       end
     end
 

--- a/spec/system/create_delete_tracks_spec.rb
+++ b/spec/system/create_delete_tracks_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "CreateDeleteTracks", type: :system do
     before { track_create(ENV['SEARCH_TRACK_NAME']) }
 
     context '表示されている曲を削除する' do
-      it '正常に削除され、プラスアイコンに変わり、再読み込みをするとその曲が表示されていない' do
+      it '正常に削除され、プラスアイコンに変わり、その曲が表示されていない' do
         visit "/mylibrary"
         expect(find('#tracks-list')).to have_content ENV['SEARCH_TRACK_NAME']
         expect(find('#tracks-list')).to have_content ENV['SEARCH_TRACK_ARTIST_NAME']


### PR DESCRIPTION
## 概要

- tracksテーブルにname、artist_name、album_name、image_urlカラムを追加
- 検索画面からの追加、削除処理前にspotify apiの配列からdataのtrackのtrack_id、name、artist_name、album_name、image_urlに格納し、送信
- 楽曲リストを表示するコンポーネントは、マイライブラリと楽曲検索画面で渡す配列の構造が異なるようになってしまったので、`$route.name`で制御
- テーブルカラム変更に伴い、楽曲追加削除のロジックも変更

## 確認方法

1. カラムを追加したので `bundle exec rails db:migrate` を実行してください
2. 楽曲検索画面から問題なく楽曲の追加、削除ができること
3. マイライブラリ画面から問題なく楽曲の削除が行えること
4. マイライブラリに楽曲があると、総曲数が表示されていて、検索すると検索結果の曲数が表示されること
---
以上をご確認ください。

## チェックリスト

プロジェクトごとにパスしなければならないルールを定義しておきましょう。例えば以下のように。

- [ ] Rubocopをパスした
- [ ] システムテストをパスした

## コメント

ご確認よろしくお願い致します。