### PR TITLE
Add: スマホ、タブレットサイズでのみボトムナビゲーションを表示

### DIFF
--- a/app/controllers/api/password_resets_controller.rb
+++ b/app/controllers/api/password_resets_controller.rb
@@ -4,9 +4,9 @@ class Api::PasswordResetsController < ApplicationController
 
   def create
     @user = User.find_by(email: params[:email])
-    if @user&.deliver_reset_password_instructions!
-      head :ok
-    end
+    return unless @user&.deliver_reset_password_instructions!
+
+    head :ok
   end
 
   def update

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,24 +1,48 @@
 <template>
   <v-app>
     <TheHeader />
-    <v-main>
+    <v-main :class="{'mb-14':isActive}">
       <TheFlashMessages />
       <router-view />
     </v-main>
-    <TheFooter />
+    <TheFooter :class="{'mb-14':isActive}" class="bottom-0" />
+    <TheBottomNavigation v-if="$vuetify.breakpoint.smAndDown" />
   </v-app>
 </template>
 
 <script>
-import TheHeader from 'components/TheHeader.vue'
-import TheFooter from 'components/TheFooter.vue'
-import TheFlashMessages from 'components/TheFlashMessages.vue'
+import TheHeader from './components/TheHeader.vue'
+import TheFooter from './components/TheFooter.vue'
+import TheFlashMessages from './components/TheFlashMessages.vue'
+import TheBottomNavigation from './components/TheBottomNavigation.vue'
 
 export default {
   components: {
     TheHeader,
     TheFooter,
-    TheFlashMessages
+    TheFlashMessages,
+    TheBottomNavigation
+  },
+
+  data() {
+    return {
+      isActive: true
+    }
+  },
+
+  created() {
+    window.addEventListener('resize', this.handleShowFooterMargin)
+    this.handleShowFooterMargin()
+  },
+
+  methods: {
+    handleShowFooterMargin() {
+      if (window.innerWidth < 960) {
+        this.isActive = true
+      } else {
+        this.isActive = false
+      }
+    }
   }
 }
 </script>

--- a/app/javascript/components/TheBottomNavigation.vue
+++ b/app/javascript/components/TheBottomNavigation.vue
@@ -1,0 +1,130 @@
+<template>
+  <v-bottom-navigation
+    app
+    color="success"
+    grow
+    v-model="value"
+  >
+    <template v-if="authUser">
+
+      <v-btn
+        :to="{ name: 'Top' }"
+        exact
+      >
+        <span style="font-size:x-small">ホーム</span>
+
+        <v-icon>mdi-home</v-icon>
+      </v-btn>
+
+      <v-btn
+        :to="{ name: 'Search' }"
+        exact
+      >
+        <span style="font-size:x-small">楽曲検索</span>
+
+        <v-icon>mdi-magnify</v-icon>
+      </v-btn>
+
+      <v-btn
+        :to="{ name: 'MyLibrary' }"
+        exact
+      >
+        <span style="font-size:x-small">マイライブラリ</span>
+
+        <v-icon>mdi-music-box-multiple</v-icon>
+      </v-btn>
+
+      <v-btn
+        :to="{ name: 'UserEdit' }"
+        exact
+      >
+        <span style="font-size:x-small">ユーザー情報</span>
+
+        <v-icon>mdi-account</v-icon>
+      </v-btn>
+
+      <v-btn @click="handleLogout">
+        <span style="font-size:x-small">ログアウト</span>
+
+        <v-icon>mdi-logout</v-icon>
+      </v-btn>
+    </template>
+
+    <template v-else>
+      <v-btn
+        :to="{ name: 'Top' }"
+        exact
+      >
+        <span style="font-size:x-small">ホーム</span>
+
+        <v-icon>mdi-home</v-icon>
+      </v-btn>
+
+      <v-btn
+        :to="{ name: 'Register' }"
+        exact
+      >
+        <span style="font-size:x-small">新規登録</span>
+
+        <v-icon>mdi-account-plus</v-icon>
+      </v-btn>
+
+      <v-btn
+        :to="{ name: 'Login' }"
+        exact
+      >
+        <span style="font-size:x-small">ログイン</span>
+
+        <v-icon>mdi-login</v-icon>
+      </v-btn>
+    </template>
+  </v-bottom-navigation>
+</template>
+
+<script>
+import { mapGetters, mapActions } from "vuex"
+
+export default {
+  name: "TheBottomNavigation",
+
+  data() {
+    return {
+      value: 1
+    }
+  },
+
+  computed: {
+    ...mapGetters("users", ["authUser"])
+  },
+
+  methods: {
+    ...mapActions("users", ["logoutUser"]),
+
+    async handleLogout() {
+      try {
+        await this.logoutUser()
+        this.$router.push({ name: "Top" })
+        this.$store.dispatch("flashMessages/showMessage",
+          {
+            message: "ログアウトしました",
+            type: "success",
+            status: true
+          }
+        )
+      } catch(error) {
+        console.log(error)
+        this.$store.dispatch("flashMessages/showMessage",
+          {
+            message: "ログアウトに失敗しました",
+            type: "error",
+            status: true
+          }
+        )
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/app/javascript/components/TheFooter.vue
+++ b/app/javascript/components/TheFooter.vue
@@ -2,17 +2,44 @@
   <v-footer
     app
     absolute
-    class="justify-center"
     color="#292929"
+    padless
     height="80"
   >
-    <div class="title font-weight-light grey--text text--lighten-1 text-center">
-      &copy; {{ (new Date()).getFullYear() }} — Song Shuffle —
-    </div>
+    <v-row
+      align="center"
+      no-gutters
+    >
+      <div class="d-flex justify-content-around">
+        <v-btn
+          color="white"
+          text
+          rounded
+        >
+          利用規約
+        </v-btn>
+          <v-btn
+          color="white"
+          text
+          rounded
+        >
+          プライバシーポリシー
+        </v-btn>
+      </div>
+      <v-col
+        class="text-center white--text"
+        cols="12"
+      >
+        {{ (new Date()).getFullYear() }} — <strong>Pickup Track</strong> —
+      </v-col>
+    </v-row>
   </v-footer>
 </template>
 
 <script>
+export default {
+  name: "TheFooter"
+}
 </script>
 
 <style scoped>

--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -107,9 +107,11 @@ import { mapGetters, mapActions } from "vuex"
 
 export default {
   name: "TheHeader",
+
   computed: {
     ...mapGetters("users", ["authUser"])
   },
+
   methods: {
     ...mapActions("users", ["logoutUser"]),
 

--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -25,77 +25,79 @@
 
     <v-spacer />
 
-    <template v-if="authUser">
-      <v-menu
-        offset-y
-        transition="scale-transition"
-      >
-        <template v-slot:activator="{ on: menu, attrs }">
-          <v-tooltip bottom>
-            <template v-slot:activator="{ on: tooltip }">
-              <v-icon
-                x-large
-                v-bind="attrs"
-                v-on="{ ...tooltip, ...menu }"
-                class="mr-12"
-                id="user-menu"
-              >
-                mdi-account
-              </v-icon>
-            </template>
-            <span>ユーザーメニュー</span>
-          </v-tooltip>
-        </template>
-        <v-list>
-          <v-list-item
-            :to="{ name: 'MyLibrary' }"
-            id="my-library"
-          >
-            <v-list-item-title>
-              マイライブラリ
-            </v-list-item-title>
-          </v-list-item>
-          <v-list-item
-            :to="{ name: 'UserEdit' }"
-            id="user-edit"
-          >
-            <v-list-item-title>
-              ユーザー情報編集
-            </v-list-item-title>
-          </v-list-item>
-          <v-divider />
-          <v-list-item
-            @click="handleLogout"
-            id="logout"
-          >
-            <v-list-item-title class="error--text">
-              ログアウト
-            </v-list-item-title>
-          </v-list-item>
-        </v-list>
-      </v-menu>
-      <v-btn
-        text
-        :to="{ name: 'Search' }"
-        class="mr-5"
-      >
-        楽曲検索
-      </v-btn>
-    </template>
-    <template v-else>
-      <v-btn
-        :to="{ name: 'Register' }"
-        class="mr-6"
-        text
-      >
-        新規登録
-      </v-btn>
-      <v-btn
-        :to="{ name: 'Login' }"
-        text
-      >
-        ログイン
-      </v-btn>
+    <template v-if="$vuetify.breakpoint.mdAndUp">
+      <template v-if="authUser">
+        <v-menu
+          offset-y
+          transition="scale-transition"
+        >
+          <template v-slot:activator="{ on: menu, attrs }">
+            <v-tooltip bottom>
+              <template v-slot:activator="{ on: tooltip }">
+                <v-icon
+                  x-large
+                  v-bind="attrs"
+                  v-on="{ ...tooltip, ...menu }"
+                  class="mr-12"
+                  id="user-menu"
+                >
+                  mdi-account
+                </v-icon>
+              </template>
+              <span>ユーザーメニュー</span>
+            </v-tooltip>
+          </template>
+          <v-list>
+            <v-list-item
+              :to="{ name: 'MyLibrary' }"
+              id="my-library"
+            >
+              <v-list-item-title>
+                マイライブラリ
+              </v-list-item-title>
+            </v-list-item>
+            <v-list-item
+              :to="{ name: 'UserEdit' }"
+              id="user-edit"
+            >
+              <v-list-item-title>
+                ユーザー情報編集
+              </v-list-item-title>
+            </v-list-item>
+            <v-divider />
+            <v-list-item
+              @click="handleLogout"
+              id="logout"
+            >
+              <v-list-item-title class="error--text">
+                ログアウト
+              </v-list-item-title>
+            </v-list-item>
+          </v-list>
+        </v-menu>
+        <v-btn
+          text
+          :to="{ name: 'Search' }"
+          class="mr-5"
+        >
+          楽曲検索
+        </v-btn>
+      </template>
+      <template v-else>
+        <v-btn
+          :to="{ name: 'Register' }"
+          class="mr-6"
+          text
+        >
+          新規登録
+        </v-btn>
+        <v-btn
+          :to="{ name: 'Login' }"
+          text
+        >
+          ログイン
+        </v-btn>
+      </template>
     </template>
   </v-app-bar>
 </template>

--- a/app/javascript/pages/top.vue
+++ b/app/javascript/pages/top.vue
@@ -283,6 +283,8 @@
 
 <script>
 export default {
+  name: "Top",
+
   data () {
     return {
       topImage: require('../images/top.jpg'),

--- a/app/javascript/pages/tracks/MyLibrary.vue
+++ b/app/javascript/pages/tracks/MyLibrary.vue
@@ -105,37 +105,8 @@ export default {
     // }
   },
 
-  // watch: {
-  //   // myLibrary() {
-  //   //   const added = this.myLibraryTracks.some(myLibraryTrack => {
-  //   //     return this.myLibrary.indexOf(myLibraryTrack.id)
-  //   //   })
-
-  //   //   this.myLibrary.forEach((myTrack, index) => {
-  //   //     this.$axios.post("tracks/my-library",{ track_id: myTrack.track_id })
-  //   //       .then(response => {
-  //   //         if (!added) {
-  //   //           response.data["index"] = index
-  //   //           this.myLibraryTracks.push(response.data)
-  //   //         }
-  //   //       })
-  //   //       .catch(error => {
-  //   //         this.$store.dispatch("flashMessages/showMessage",
-  //   //           {
-  //   //             message: "ライブラリの読み込みに失敗しました",
-  //   //             type: "error",
-  //   //             status: true
-  //   //           }
-  //   //         )
-  //   //         console.log(error)
-  //   //       })
-  //   //   })
-  //   // }
-  // },
-
   created() {
     this.fetchTracks()
-    console.log(this.$route.params)
   },
 
   methods: {

--- a/app/javascript/pages/tracks/components/PickupTrack.vue
+++ b/app/javascript/pages/tracks/components/PickupTrack.vue
@@ -27,6 +27,7 @@
           v-bind="attrs"
           v-on="on"
           @click="handlePickupTrack"
+          class="mb-13"
           id="pickup-fab"
         >
           <v-icon>mdi-music-note</v-icon>
@@ -103,7 +104,7 @@ export default {
   },
 
   created() {
-    window.addEventListener("scroll", this.handleShowButton);
+    window.addEventListener("scroll", this.handleShowButton)
   },
 
   methods: {

--- a/app/javascript/pages/tracks/components/PickupTrack.vue
+++ b/app/javascript/pages/tracks/components/PickupTrack.vue
@@ -86,7 +86,7 @@ export default {
 
   props: {
     track: {
-      type: Object,
+      type: [Object, String],
       required: true
     },
 


### PR DESCRIPTION
## 概要

- ヘッダーメニューはパソコン等の大きい画面の時のみ表示させる
- スマホ等の小さい画面の際はボトムナビゲーションを表示させる

## 確認方法

1. デベロッパーツールでサイズをレスポンシブにして、縮めていくとヘッダーメニューが消えること
2. ヘッダーメニューが消えるとその代わり、ボトムナビゲーションが表示されること
3. ボトムナビゲーションが表示されている時、フッターメニューが被らずに表示されていること
---
以上をご確認ください。

## チェックリスト

- [x] Rubocopをパスした

## コメント

ご確認よろしくお願い致します。